### PR TITLE
Add missing android:exported in PrinterReceiver

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "com.google.zxing:core:3.4.1"
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.google.zxing:core:3.4.1"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
     buildToolsVersion "29.0.3"
 
     defaultConfig {
+        compileSdkVersion 33
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 2
         versionName "1.0.1"
     }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.sunmi.v2.printer">
   <application>
-  <receiver android:name="com.sunmi.v2.printer.PrinterReceiver" android:enabled="true">
+  <receiver android:name="com.sunmi.v2.printer.PrinterReceiver" android:enabled="true" android:exported="true">
       <intent-filter android:priority="1000">
         <!-- 缺纸异常 -->
         <action android:name="woyou.aidlservice.jiuv5.OUT_OF_PAPER_ACTION" />  

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": "16.13.1",
+    "react": ">=16",
     "react-native": "^0.63.3"
   },
   "homepage": "https://github.com/suraneti/react-native-sunmi-v2-printer#readme",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react": ">=16",
-    "react-native": "^0.63.3"
+    "react-native": ">=0.63.3"
   },
   "homepage": "https://github.com/suraneti/react-native-sunmi-v2-printer#readme",
   "directories": {


### PR DESCRIPTION
All activity, activity-alias, service, or receiver components that have intent-filter needs android:exported defined to be able to compile in Android 12.