### PR TITLE
Change dependencies compile to implementation for Gradle 7+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "com.google.zxing:core:3.4.1"
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.google.zxing:core:3.4.1"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.sunmi.v2.printer">
   <application>
-  <receiver android:name="com.sunmi.v2.printer.PrinterReceiver" android:enabled="true">
+  <receiver android:name="com.sunmi.v2.printer.PrinterReceiver" android:enabled="true" android:exported="true">
       <intent-filter android:priority="1000">
         <!-- 缺纸异常 -->
         <action android:name="woyou.aidlservice.jiuv5.OUT_OF_PAPER_ACTION" />  


### PR DESCRIPTION
With Gradle version 7 or higher, compile is no longer supported and needs to be changed into implementation.